### PR TITLE
Add empty list [] test for lab1 average to avoid passing tests if stu…

### DIFF
--- a/lab1/test/lab1_test.exs
+++ b/lab1/test/lab1_test.exs
@@ -30,5 +30,6 @@ defmodule Lab1Test do
     assert Lab1.average([5]) == 5
     assert Lab1.average([5, 5]) == 5
     assert Lab1.average([5, 6, 7]) == 6
+    assert Lab1.average([]) == nil
   end
 end


### PR DESCRIPTION
Add empty list [] test for lab1 average to avoid passing tests if student uses a divide by 0 (length of list) solution

Example of a solution that should fail the tests but doesn't:
```
  def average(list) do
    sum(list) / length(list)
  end 
```